### PR TITLE
Syntax Error Fix

### DIFF
--- a/phonetypes/Null3FolderType.py
+++ b/phonetypes/Null3FolderType.py
@@ -45,8 +45,8 @@ class Null3FolderType(PhoneType):
             adf_index = adf_file[3:]
 
             # Get the corresponding JAR and SP files
-            jar_file = os.path.join(folder_paths["jar"], f"{folder_paths["jar"][-3:]}{adf_index}")
-            sp_file = os.path.join(folder_paths["sp"], f"{folder_paths["sp"][-2:]}{adf_index}")
+            jar_file = os.path.join(folder_paths["jar"], f"{folder_paths['jar'][-3:]}{adf_index}")
+            sp_file = os.path.join(folder_paths["sp"], f"{folder_paths['sp'][-2:]}{adf_index}")
 
             # Get the properties from the JAM file
             jam_props = None


### PR DESCRIPTION
Fixed the quotation marks issue that makes the script crash by changing "jar" and "sp" to 'jar' and 'sp'

Traceback (most recent call last):
  File "D:\Dumps\Panasonic\P-04C\KTdumper_2025-03-27_00-15-25_p-04c_dump_nand\kttools.py", line 4, in <module>
    from phonetypes import DFType, SHType, Null3FolderType, ModernNType, NullPlain3FolderType, NullPlain3FolderCSPType, ModernPType, SOType
  File "D:\Dumps\Panasonic\P-04C\KTdumper_2025-03-27_00-15-25_p-04c_dump_nand\phonetypes\Null3FolderType.py", line 48
    jar_file = os.path.join(folder_paths["jar"], f"{folder_paths["jar"][-3:]}{adf_index}")